### PR TITLE
Compile with -lpthread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ fi
 
 case "$(uname -s)" in
   Linux | *BSD)
-    LIBS="$LIBS -lutil -lcrypt"
+    LIBS="$LIBS -lutil -lcrypt -lpthread"
     AC_DEFINE(NOSTREAMS, 1, [Don't use SVR4 streams support in ttyrec.])
   ;;
 esac


### PR DESCRIPTION
Without this change, `make` returned the following error:

```
[...]
cc -g -O2 -Wall -Wno-unused -o dgamelaunch dgl-common.o ttyrec.o dgamelaunch.o io.o ttyplay.o mygetnstr.o stripgfx.o strlcpy.o strlcat.o setproctitle.o y.tab.o lex.yy.o -lncursesw  -lfl -lutil -lcrypt -lsqlite3 -lrt
/usr/bin/ld: dgamelaunch.o: undefined reference to symbol 'sem_post@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [dgamelaunch] Error 1
```
